### PR TITLE
Tweaking Flutter-Auth-Ui to diversify its usecases

### DIFF
--- a/lib/src/screens/supa_email_auth.dart
+++ b/lib/src/screens/supa_email_auth.dart
@@ -11,13 +11,15 @@ class SupaEmailAuth extends StatefulWidget {
   final String? redirectUrl;
   final void Function(GotrueSessionResponse response)? onSuccess;
   final bool Function(GoTrueException error)? onError;
+  final String? initialEmail;
 
   const SupaEmailAuth(
       {Key? key,
       required this.authAction,
       this.redirectUrl,
       this.onSuccess,
-      this.onError})
+      this.onError,
+      this.initialEmail})
       : super(key: key);
 
   @override
@@ -42,6 +44,7 @@ class _SupaEmailAuthState extends State<SupaEmailAuth> {
 
   @override
   Widget build(BuildContext context) {
+    if (widget.initialEmail != null) _email.text = widget.initialEmail!;
     final isSigningIn = widget.authAction == AuthAction.signIn;
 
     return Form(

--- a/lib/src/screens/supa_email_auth.dart
+++ b/lib/src/screens/supa_email_auth.dart
@@ -43,10 +43,14 @@ class _SupaEmailAuthState extends State<SupaEmailAuth> {
   }
 
   @override
-  Widget build(BuildContext context) {
+  void initState() {
     if (widget.initialEmail != null) _email.text = widget.initialEmail!;
-    final isSigningIn = widget.authAction == AuthAction.signIn;
+    super.initState();
+  }
 
+  @override
+  Widget build(BuildContext context) {
+    final isSigningIn = widget.authAction == AuthAction.signIn;
     return Form(
       autovalidateMode: AutovalidateMode.onUserInteraction,
       key: _formKey,

--- a/lib/src/utils/constants.dart
+++ b/lib/src/utils/constants.dart
@@ -1,53 +1,71 @@
 import 'package:flutter/material.dart';
 
-Future<void> successAlert(BuildContext context) {
-  return showDialog(
-    context: context,
-    builder: (BuildContext context) {
-      return AlertDialog(
-        contentPadding: const EdgeInsets.all(16),
-        title: const Text(
-          'Success',
-          style: TextStyle(color: Colors.green),
-        ),
-        actions: [
-          TextButton(
-            onPressed: () => Navigator.pop(context),
-            child: const Text(
-              'OK',
-              style:
-                  TextStyle(fontWeight: FontWeight.bold, color: Colors.green),
-            ),
-          ),
-        ],
-      );
-    },
+Future<void> successAlert(BuildContext context) async {
+  // return showDialog(
+  //   context: context,
+  //   builder: (BuildContext context) {
+  //     return AlertDialog(
+  //       contentPadding: const EdgeInsets.all(16),
+  //       title: const Text(
+  //         'Success',
+  //         style: TextStyle(color: Colors.green),
+  //       ),
+  //       actions: [
+  //         TextButton(
+  //           onPressed: () => Navigator.pop(context),
+  //           child: const Text(
+  //             'OK',
+  //             style:
+  //                 TextStyle(fontWeight: FontWeight.bold, color: Colors.green),
+  //           ),
+  //         ),
+  //       ],
+  //     );
+  //   },
+  // );
+
+  final snackBar = SnackBar(
+    content: const Text(style: TextStyle(color: Colors.green), 'Success!'),
+    action: SnackBarAction(
+      label: 'Ok',
+      onPressed: () {},
+    ),
   );
+  ScaffoldMessenger.of(context).showSnackBar(snackBar);
 }
 
-Future<void> warningAlert(BuildContext context, String errMsg) {
-  return showDialog(
-    context: context,
-    builder: (BuildContext context) {
-      return AlertDialog(
-        contentPadding: const EdgeInsets.all(16),
-        title: Text(
-          errMsg,
-          style: const TextStyle(color: Colors.redAccent),
-        ),
-        actions: [
-          TextButton(
-            onPressed: () => Navigator.pop(context),
-            child: const Text(
-              'OK',
-              style: TextStyle(
-                  fontWeight: FontWeight.bold, color: Colors.redAccent),
-            ),
-          ),
-        ],
-      );
-    },
+Future<void> warningAlert(BuildContext context, String errMsg) async {
+  // return showDialog(
+  //   context: context,
+  //   builder: (BuildContext context) {
+  //     return AlertDialog(
+  //       contentPadding: const EdgeInsets.all(16),
+  //       title: Text(
+  //         errMsg,
+  //         style: const TextStyle(color: Colors.redAccent),
+  //       ),
+  //       actions: [
+  //         TextButton(
+  //           onPressed: () => Navigator.pop(context),
+  //           child: const Text(
+  //             'OK',
+  //             style: TextStyle(
+  //                 fontWeight: FontWeight.bold, color: Colors.redAccent),
+  //           ),
+  //         ),
+  //       ],
+  //     );
+  //   },
+  // );
+
+  final snackBar = SnackBar(
+    content: Text(style: const TextStyle(color: Colors.redAccent), errMsg),
+    action: SnackBarAction(
+      label: 'Ok',
+      onPressed: () {},
+    ),
   );
+  ScaffoldMessenger.of(context).showSnackBar(snackBar);
 }
 
 SizedBox spacer(double height) {


### PR DESCRIPTION
- Chore: style, typos, update dependencies, reword buttons,
- Add callback when succeeding supabase action
- Add asynchronous management on buttons with circular progress indicator
- Display error that make sense
- MacOS runnable
- Create ```onSuccess``` and ```onError```
- Signin when user already signed up but still uses signup page
-  Refactor Signin method
- Call successAlert if onSuccess is not provided
- Make accesstoken optional for resetPassword
- SupaEmailAuth add default email in initState
- Show snackbar instead of dialog